### PR TITLE
Enhancements - x86 support (WoW64 + native), ability to change function prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ Using the `--preset common` switch will create a header/ASM pair with the follow
 
 ## Caveats and Limitations
 
-- Only 64-bit Windows is supported at this time.
 - System calls from the graphical subsystem (`win32k.sys`) are not supported.
 - Tested on Visual Studio 2019 (v142) with Windows 10 SDK.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ Using the `--preset common` switch will create a header/ASM pair with the follow
 2. In Visual Studio, go to *Project* → *Build Customizations...* and enable MASM.
 3. In the *Solution Explorer*, add the .h and .c/.asm files to the project as header and source files, respectively.
 4. Go to the properties of the ASM file, and set the *Item Type* to *Microsoft Macro Assembler*.
-5. Ensure that the project platform is set to x64. 32-bit projects are not supported at this time.
 
 ## Caveats and Limitations
 

--- a/data/base.c
+++ b/data/base.c
@@ -24,7 +24,11 @@ BOOL SW2_PopulateSyscallList()
     // Return early if the list is already populated.
     if (SW2_SyscallList.Count) return TRUE;
 
+#if defined(_WIN64)
     PSW2_PEB Peb = (PSW2_PEB)__readgsqword(0x60);
+#else
+    PSW2_PEB Peb = (PSW2_PEB)__readfsdword(0x30);
+#endif
     PSW2_PEB_LDR_DATA Ldr = Peb->Ldr;
     PIMAGE_EXPORT_DIRECTORY ExportDirectory = NULL;
     PVOID DllBase = NULL;


### PR DESCRIPTION
Seems to work. Please check if 32 bit version asm is correct. 

I was wondering if a separate .asm file should be generated for this. Now the generated .asm will build on both architectures using `IFDEF RAX`.

Some ideas worth mentioning to improve this even further:

- Add `-x86`/`-32bit` argument to optionally enable 32-bit support

Custom function prefix only works with `Nt` functions. I don't know if it's needed for `Rtl` as well.

Closes #7