### PR TITLE
Add support for LLVM/clang compatible .s files

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ Using the `--preset common` switch will create a header/ASM pair with the follow
 4. Go to the properties of the ASM file, and set the *Item Type* to *Microsoft Macro Assembler*.
 5. Ensure that the project platform is set to x64. 32-bit projects are not supported at this time.
 
+## Using with LLVM/Clang
+
+SysWhispers2 outputs a clang compatible `.s` file which contains the ASM stubs. This can be used with llvm to compile your code. For example, using the `CreateRemoteThread` DLL injection example above:
+
+```
+clang -D nullptr=NULL main.c syscall.c syscallstubs.s -o test.exe
+```
+
 ## Caveats and Limitations
 
 - Only 64-bit Windows is supported at this time.

--- a/data/base.h
+++ b/data/base.h
@@ -6,7 +6,7 @@
 #ifndef SW2_HEADER_H_
 #define SW2_HEADER_H_
 
-#include <Windows.h>
+#include <windows.h>
 
 #define SW2_SEED <SEED_VALUE>
 #define SW2_ROL8(v) (v << 8 | v >> 24)

--- a/syswhispers.py
+++ b/syswhispers.py
@@ -36,6 +36,11 @@ class SysWhispers(object):
                 output_asm.write((self._get_function_asm_code(function_name) + '\n').encode())
             output_asm.write(b'end')
 
+        # Write ASM .s file.
+        with open(f'{basename}{basename_suffix}.s', 'wb') as output_asm:
+            for function_name in function_names:
+                output_asm.write((self._get_function_asm_code_s(function_name) + '\n').encode())
+
         # Write header file.
         with open('./data/base.h', 'rb') as base_header:
             with open(f'{basename}.h', 'wb') as output_header:
@@ -61,6 +66,7 @@ class SysWhispers(object):
         print(f'\t{basename}.h')
         print(f'\t{basename}.c')
         print(f'\t{basename}{basename_suffix}.asm')
+        print(f'\t{basename}{basename_suffix}.s')
 
     def _get_typedefs(self, function_names: list) -> list:
         def _names_to_ids(names: list) -> list:
@@ -158,6 +164,32 @@ class SysWhispers(object):
 
         return code
 
+    def _get_function_asm_code_s(self, function_name: str) -> str:
+        function_hash = self._get_function_hash(function_name)
+
+        # Generate 64-bit ASM code.
+        code = '\t.intel_syntax\n'
+        code += f'\t.def {function_name}\n'
+        code += f'\t.global {function_name}\n'
+        code += f'{function_name}:\n'
+        code += '\tmov [rsp +8], rcx  // Save registers.\n'
+        code += '\tmov [rsp+16], rdx\n'
+        code += '\tmov [rsp+24], r8\n'
+        code += '\tmov [rsp+32], r9\n'
+        code += '\tsub rsp, 0x28\n'
+        code += f'\tmov ecx, 0x{function_hash:08X}        // Load function hash into ECX.\n'
+        code += '\tcall SW2_GetSyscallNumber  // Resolve function hash into syscall number.\n'
+        code += '\tadd rsp, 0x28\n'
+        code += '\tmov rcx, [rsp +8]          // Restore registers.\n'
+        code += '\tmov rdx, [rsp+16]\n'
+        code += '\tmov r8, [rsp+24]\n'
+        code += '\tmov r9, [rsp+32]\n'
+        code += '\tmov r10, rcx\n'
+        code += '\tsyscall                    // Invoke system call.\n'
+        code += '\tret\n'
+        code += '\t.endef\n'
+
+        return code
 
 if __name__ == '__main__':
     print(


### PR DESCRIPTION
This pull request adds an additional output file to SysWhispers2 which contains a clang-compatible `.s` file, allowing SysWhispers2 to be used in projects compiled with clang.

The case of the `Windows.h` include in `base.h` has also been changed to make SysWhispers2 output a file that can compile out-of-the-box on linux with headers from mingw.